### PR TITLE
changed to prevent security vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1322,7 +1322,7 @@
         "log-utils": "0.2.1",
         "pointer-symbol": "1.0.0",
         "radio-symbol": "2.0.0",
-        "set-value": "2.0.0",
+        "set-value": "2.0.1",
         "strip-color": "0.1.0",
         "terminal-paginator": "2.0.2",
         "toggle-array": "1.0.1"


### PR DESCRIPTION
package-lock.json update suggested: set-value ~> 2.0.1.